### PR TITLE
fix: 마이페이지의 탭 변경시 발생하는 무한 스크롤 관련 문제 해결

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -55,6 +55,7 @@ const MyPage = () => {
   const closeModal = () => setIsModalOpen(false);
 
   const handleFilterChange = (type: "review" | "scrap") => {
+    setLastTimestamp(new Date(3000, 0, 1).toISOString());
     setActiveFilter(type);
   };
 


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- 마이페이지 수정 : "내가 작성한 리뷰" 탭에서 무한 스크롤이 한번이라도 트리거 된 후 "스크랩한 장소" 탭으로 이동, 다시 "내가 작성한 리뷰"탭으로 돌아가면 이전 스크롤된 리뷰 데이터 사라짐 문제 해결

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### 1. Mypage.tsx 코드 변경
- 탭 변경할때마다 리뷰 조회 api 재호출되도록 변경

## 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요 -->
- #117

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. "내가 작성한 리뷰" 탭에서 무한 스크롤이 한번이라도 트리거 된 후 "스크랩한 장소" 탭으로 이동, 다시 "내가 작성한 리뷰"탭으로 돌아가면 처음 리뷰 데이터부터 조회되는지 확인

## 추가 설명
<!-- 리뷰어가 참고해야 할 내용이나 우려사항을 작성해주세요 -->
### Known Issues
- #117 이슈의 "무한스크롤 트리거 발동 시 더 불러올 리뷰가 없으면 스크롤이 살짝 튀는 문제"를 제외한 모든 문제가 해결된 상태입니다

