### PR TITLE
fix: 한 리뷰에 대한 이미지 정렬을 최근 등록순으로 정렬하는 기능 구현

### DIFF
--- a/src/entities/review/ui/reviewerInfo/ReviewerInfo.tsx
+++ b/src/entities/review/ui/reviewerInfo/ReviewerInfo.tsx
@@ -7,6 +7,7 @@ import myProfileIcon from "@shared/assets/images/profile/myProfile.svg";
 import moreIcon from "@shared/assets/images/more.svg";
 import { useProfileImageApi } from "@/shared/api/user/useProfileImagesApi";
 import { useNavigate } from "react-router-dom";
+import { useReviewImageApi } from "@/shared/api/images";
 
 interface ReviewerInfoProps {
   nickname: string;
@@ -32,25 +33,8 @@ const ReviewerInfo = ({
   const reviewMoreRef = useRef<HTMLDivElement | null>(null);
   const isOwner = currentUserId === userId;
   const navigate = useNavigate();
-
-  const { getProfileImage } = useProfileImageApi();
-  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    const loadProfileImage = async () => {
-      if (isProfileImageExist && userId) {
-        try {
-          const imageUrl = await getProfileImage(userId);
-          setProfileImageUrl(imageUrl);
-        } catch (error) {
-          console.error("프로필 이미지 로드 실패:", error);
-          setProfileImageUrl(null);
-        }
-      }
-    };
-
-    loadProfileImage();
-  }, [isProfileImageExist, userId, getProfileImage]);
+  const { getProfileImageUrl } = useReviewImageApi();
+  const profileImageUrl = getProfileImageUrl(String(userId));
 
   // 표시할 버튼 개수 계산
   const getVisibleButtonCount = () => {

--- a/src/entities/review/ui/reviewerInfo/ReviewerInfo.tsx
+++ b/src/entities/review/ui/reviewerInfo/ReviewerInfo.tsx
@@ -86,7 +86,7 @@ const ReviewerInfo = ({
         <img
           onClick={()=>{navigate(`/userpage/${userId}`)}}
           className={styles.reviewerInfo__profilePicture}
-          src={profileImageUrl || (isOwner ? myProfileIcon : profileIcon)}
+          src={(isProfileImageExist && profileImageUrl) || (isOwner ? myProfileIcon : profileIcon)}
           alt={`${nickname}의 프로필`}
         />
         <div className={styles.reviewerInfo__details}>

--- a/src/entities/userListItem/UserListItem.tsx
+++ b/src/entities/userListItem/UserListItem.tsx
@@ -3,6 +3,7 @@ import type { UserSearchResponse } from '@/shared/api/user/types';
 import defaultProfile from "@shared/assets/images/profile/profile.svg";
 import { useEffect, useState } from 'react';
 import { useProfileImageApi } from '@shared/api/user/useProfileImagesApi';
+import { useReviewImageApi } from '@/shared/api/images';
 
 interface UserItemProps extends UserSearchResponse {
   onSelect: () => void;
@@ -17,24 +18,8 @@ const UserItem = ({
   onSelect,
   renderFollowButton
 }: UserItemProps) => {
-  const { getProfileImage } = useProfileImageApi();
-  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    const loadProfileImage = async () => {
-      if (isProfileImageExist) {
-        try {
-          const imageUrl = await getProfileImage(userId);
-          setProfileImageUrl(imageUrl);
-        } catch (error) {
-          console.error("프로필 이미지 로드 실패:", error);
-          setProfileImageUrl(null);
-        }
-      }
-    };
-
-    loadProfileImage();
-  }, [isProfileImageExist, userId, getProfileImage]);
+  const { getProfileImageUrl } = useReviewImageApi();
+  const profileImageUrl = getProfileImageUrl(String(userId));
 
   return (
     <li className={styles.userItem}>

--- a/src/shared/api/user/useProfileImagesApi.ts
+++ b/src/shared/api/user/useProfileImagesApi.ts
@@ -7,13 +7,12 @@ export const useProfileImageApi = () => {
   const { get, post } = useApi();
   const prevUrl = useRef<string | null>(null);
 
+  // 더이상 사용하지 않을때 삭제 예정
   const getProfileImage = useCallback(
     async (userId: number): Promise<string | null> => {
       try {
-        // 캐시 방지를 위한 타임스탬프 추가
-        const timestamp = Date.now();
         const response: Blob = await get(
-          `${PROFILE_IMAGE_URL}/${userId}?t=${timestamp}`, 
+          `${PROFILE_IMAGE_URL}/${userId}`, 
           {
             responseType: "blob",
           }

--- a/src/shared/ui/photoSwiper/PhotoSwiper.module.scss
+++ b/src/shared/ui/photoSwiper/PhotoSwiper.module.scss
@@ -64,3 +64,11 @@
   object-fit: cover;
   border-radius: 8px;
 }
+
+.swiper__loading {
+  height: 185px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/shared/ui/photoSwiper/PhotoSwiper.tsx
+++ b/src/shared/ui/photoSwiper/PhotoSwiper.tsx
@@ -4,9 +4,11 @@ import "swiper/css";
 import "swiper/css/pagination";
 import styles from "./PhotoSwiper.module.scss";
 import { Pagination } from "swiper/modules";
-import { FC, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { useReviewImageApi } from "@shared/api/images";
 import FullScreenViewer from "../fullScreenViewer/FullScreenViewer";
+import Lottie from "lottie-react";
+import spinnerAnimation from '@shared/assets/images/spinner.json';
 
 interface PhotoSwiperProps {
   imageIds: string[];
@@ -23,7 +25,10 @@ const PhotoSwiper: FC<PhotoSwiperProps> = ({
 }) => {
   const [viewerOpen, setViewerOpen] = useState(false);
   const [initialSlideIndex, setInitialSlideIndex] = useState(0);
-  const { getImageUrl } = useReviewImageApi();
+  const { getImageUrlWithModified } = useReviewImageApi();
+  const [ isAllImageLoading, setIsAllImageLoading ] = useState(true);
+  const [images, setImages] = useState<{ imageId: string; imageUrl: string; modified: number }[]>([]);
+
 
   // imageIds가 없고 cafeName과 showChips가 있는 경우에도 Chips 렌더링
   if ((!imageIds || imageIds.length === 0) && showChips && cafeName) {
@@ -39,48 +44,86 @@ const PhotoSwiper: FC<PhotoSwiperProps> = ({
     return null;
   }
 
+  useEffect(() => {
+    // 모든 이미지 다 받을때까지 무한 로딩
+    const fetchImageUrls = async () => {
+      const newImages = await Promise.all(
+        imageIds.map(async (imageId) => {
+          const { imageUrl, modified } = await getImageUrlWithModified(imageId);
+          if (imageUrl === null || modified === null) throw new Error("이미지 로드 실패했습니다.");
+          console.log(imageUrl);
+          return { imageId, imageUrl, modified,};
+        })
+      );
+      // modified 오래된 날짜 순으로 이미지 정렬
+      setImages(newImages.sort((a, b) => (a.modified ?? 0) - (b.modified ?? 0)));
+    };
+  
+    if (imageIds && imageIds.length > 0) {
+      fetchImageUrls();
+    }
+  }, [imageIds]);
+
+
+  useEffect(() => {
+    if (images.length > 0){
+      setIsAllImageLoading(false);
+    }
+  }, [images])
+
+
   return (
     <>
-      <Swiper
-        className={styles.swiper}
-        pagination={true}
-        modules={[Pagination]}
-        spaceBetween={50}
-        slidesPerView={1}
-      >
-        {imageIds.map((imageId, index) => (
-          <SwiperSlide
-            key={imageId}
-            className={styles.swiperSlide}
-            onClick={() => {
-              setInitialSlideIndex(index);
-              setViewerOpen(true);
-            }}
-          >
-            <img
-              src={getImageUrl(imageId)}
-              alt="Review"
-              className={styles.image}
-            />
-            {showChips && cafeName && (
-              <div
-                className={styles.chipsWrap}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Chips cafeName={cafeName} cafeId={cafeId} />
-              </div>
-            )}
-          </SwiperSlide>
-        ))}
-      </Swiper>
+      {isAllImageLoading ? 
+        <div className={styles.swiper__loading}>
+          <Lottie
+          animationData={spinnerAnimation}
+          style={{ width: 40, height: 40 }}
+          loop={true}
+          />
+        </div>
+        : <><Swiper
+          className={styles.swiper}
+          pagination={true}
+          modules={[Pagination]}
+          spaceBetween={50}
+          slidesPerView={1}
+        >
+          {images.map((image, index) => (
+            <SwiperSlide
+              key={image.imageId}
+              className={styles.swiperSlide}
+              onClick={() => {
+                setInitialSlideIndex(index);
+                setViewerOpen(true);
+              }}
+            >
+              <img
+                src={image.imageUrl}
+                alt="Review"
+                className={styles.image}
+              />
+              {showChips && cafeName && (
+                <div
+                  className={styles.chipsWrap}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Chips cafeName={cafeName} cafeId={cafeId} />
+                </div>
+              )}
+            </SwiperSlide>
+          ))}
+          </Swiper>
 
-      {viewerOpen && (
-        <FullScreenViewer
-          images={imageIds.map(getImageUrl)}
-          initialIndex={initialSlideIndex}
-          onClose={() => setViewerOpen(false)}
-        />
-      )}
+          {viewerOpen && !isAllImageLoading && (
+            <FullScreenViewer
+            images={images.map(image => (image.imageUrl))}
+            initialIndex={initialSlideIndex}
+            onClose={() => setViewerOpen(false)}
+            />
+          )}
+        </>
+      }
     </>
   );
 };

--- a/src/shared/ui/photoSwiper/PhotoSwiper.tsx
+++ b/src/shared/ui/photoSwiper/PhotoSwiper.tsx
@@ -51,7 +51,6 @@ const PhotoSwiper: FC<PhotoSwiperProps> = ({
         imageIds.map(async (imageId) => {
           const { imageUrl, modified } = await getImageUrlWithModified(imageId);
           if (imageUrl === null || modified === null) throw new Error("이미지 로드 실패했습니다.");
-          console.log(imageUrl);
           return { imageId, imageUrl, modified,};
         })
       );


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- 리뷰 이미지를 최근 등록순으로 정렬하여 표시하는 기능 구현
- Blob URL이 누적되지 않도록 컴포넌트 언마운트 시 URL 해제 처리 추가

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
## api 코드 관련
### 1. 이미지 조회 시 last-modified 값과 Blob 동시 조회
#### 기존 문제점
- 기존에는 이미지 URL만 가져왔기 때문에 등록순 정렬이 불가능
- 하지만 Blob 요청을 하면 헤더값 (last-modified) 를 가져올 수 없음

#### 변경된 코드
```typescript
const getImageUrlWithModified = async (imageId: string): Promise<{imageUrl: string|null; modified: number|null}> => {
  const response = await get<Response>(
    `요청Url`, {
      responseType: "blob",
      transformResponse: (data, headers) => ({ blob:data, headers }),  //Blob과 headers 동시 유지
    }
  );
  const modifiedHeader = response.headers?.["last-modified"];         //last-modified 값 조회
  const modified = modifiedHeader ? Date.parse(modifiedHeader) : null;

  const blob = response.blob;
  if (!(blob instanceof Blob)) throw new Error("응답 데이터가 Blob이 아닙니다.");
    
 // 이미지 url 변환하는 코드 생략  (아래에서 설명)
);
``` 
- Blob 데이터 + last-modified 헤더값을 함께 조회하도록 수정.
- transformResponse 옵션을 사용하여 Blob 데이터 + 헤더값을 동시에 가져올 수 있도록 처리

### 2. 여러 개의 Object URL 관리 방식 채택
#### 기존 문제점
- 기존에는 useRef를 사용해 단 하나의 URL만 저장했음
- 새로운 URL을 생성할 때마다 기존 URL을 삭제해야 해서 한 개의 이미지만 표시 가능
#### 변경 전 코드
```typescript
const prevUrl = useRef<string | null>(null);          //단 하나의 url만 저장

const getImageUrl= async () => {
  // 이미지 조회하는 코드 생략

  // 기존 URL 해제
  if (prevUrl.current) {
    URL.revokeObjectURL(prevUrl.current);
  }
  // 새 URL 생성
  const imageUrl = URL.createObjectURL(response);
  prevUrl.current = imageUrl;

  return imageUrl;
);
``` 




#### 변경 후 코드
```typescript
const prevUrls = useRef(new Set<string>());

const getImageUrlWithModified = async () => {
  // last-modified 값과 이미지 조회하는 코드 생략.. 위에서 설명함

  // 새 URL 생성
  const imageUrl = URL.createObjectURL(blob);
  prevUrls.current.add(imageUrl);
  return imageUrl;
);

// useEffect의 cleanup 함수 (컴포넌트 언마운트 될때 실행됨)
// 새로고침 또는 페이지 벗어날 때 모든 URL 해제
useEffect(() => {
  return () => {
    if (prevUrls.current.size > 0){
      prevUrls.current.forEach((url) => URL.revokeObjectURL(url));   //이전 모든 URL 해제
      prevUrls.current.clear();
    }
  };
}, []);
``` 
- 여러 개의 이미지 URL을 관리할 수 있도록 Set<string>을 사용
- 컴포넌트가 언마운트 될때 모든 URL을 해제하여 누수를 방지함.
-> 여러개의 이미지를 불러올 수 있다!

### 전체 코드
#### useReviewImageApi 훅
```typescript
const prevUrls = useRef(new Set<string>());
const getImageUrlWithModified = useCallback(
  async (imageId: string): Promise<{imageUrl: string|null; modified: number|null}> => {
    try {
      const response = await get<Response>(
        `${API_URL}/api/images/review/${imageId}`, {
          responseType: "blob",
          transformResponse: (data, headers) => ({ blob:data, headers }),  //headers 유지
        }
      );
      const modifiedHeader = response.headers?.["last-modified"];
      const modified = modifiedHeader ? Date.parse(modifiedHeader) : null;
        
      const blob = response.blob;
      if (!(blob instanceof Blob)) throw new Error("응답 데이터가 Blob이 아닙니다.");

      const imageUrl = URL.createObjectURL(blob);
      prevUrls.current.add(imageUrl);
      return { imageUrl, modified };
    } catch (error) {
      console.error("이미지 불러오기 실패:", error);
      return { imageUrl: null, modified: null };
    }
  },
  [get]
);


// useEffect의 cleanup 함수 (컴포넌트 언마운트 될때 실행됨)
// 새로고침 또는 페이지 벗어날 때 모든 URL 해제
useEffect(() => {
  return () => {
    if (prevUrls.current.size > 0){
    prevUrls.current.forEach((url) => URL.revokeObjectURL(url));
    prevUrls.current.clear();
    }
  };
}, []);
``` 

## 컴포넌트 관련
### 1. PhotoSwiper.tsx
#### 기존 문제점
- 기존에는 백엔드에서 받은 이미지 ID 리스트 그대로 사용했기 때문에 등록순 정렬이 불가능함.

#### 추가된 코드
```typescript
useEffect(() => {
  // 모든 이미지 다 받을때까지 무한 로딩
  const fetchImageUrls = async () => {
    const newImages = await Promise.all(
      imageIds.map(async (imageId) => {
        const { imageUrl, modified } = await getImageUrlWithModified(imageId);     //이미지 blob으로 로드
        if (imageUrl === null || modified === null) throw new Error("이미지 로드 실패했습니다.");
        return { imageId, imageUrl, modified,};
      })
    );
    // modified 오래된 날짜 순으로 이미지 정렬
    setImages(newImages.sort((a, b) => (a.modified ?? 0) - (b.modified ?? 0)));
  };

  if (imageIds && imageIds.length > 0) {
    fetchImageUrls();
  }
}, [imageIds]);
``` 
- 모든 이미지의 last-modified 값을 조회한 후 정렬하여 출력하도록 수정
- 모든 이미지 로드가 완료될 때까지 로딩 UI를 표시한 후, 최신 등록순으로 정렬하여 표시

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. 이미지 정렬 테스트 
 리뷰 이미지가 최근 등록순으로 표시되는지 확인
2. 새로고침or언마운트시 url 잘 삭제되는지 테스트
 홈에서 리뷰 조회시 개발자 도구 콘솔에서 출력된 blob url 중 하나 복사 -> 새로고침하거나 다른 페이지로 이동 -> 콘솔에 URL.revokeObjectURL("복사한url") 입력 후 undefined 나오면 성공
테스트 성공한 스크린샷
![image](https://github.com/user-attachments/assets/aab01149-72cd-4bef-a93a-2f703b8c7eba)

## 머지하기 전에 테스트에 사용했던 console.log 지워야 해서 approve만 해주세요!